### PR TITLE
Fixing a segfault for the case where dims_l is 0

### DIFF
--- a/bin/makemex.m
+++ b/bin/makemex.m
@@ -82,7 +82,7 @@ if( any(strcmpi(what,'ecos')) || any(strcmpi(what,'all')) )
     fprintf('Compiling ecos...');
     i = sprintf('-I../ecos/include -I../ecos/external/SuiteSparse_config -I../ecos/external/ldl/include -I../ecos/external/amd/include');
     cmd = sprintf('mex -c -O %s -DMATLAB_MEX_FILE -DCTRLC=1 %s', d, i);
-    files = {'ecos', 'kkt', 'cone', 'spla', 'ctrlc', 'timer', 'preproc', 'splamm', 'equil'};
+    files = {'ecos', 'kkt', 'cone', 'spla', 'ctrlc', 'timer', 'preproc', 'splamm', 'equil', 'expcone', 'wright_omega'};
     for i = 1 : length (files)
         cmd = sprintf ('%s ../ecos/src/%s.c', cmd, files {i}) ;
     end
@@ -120,7 +120,7 @@ if( any(strcmpi(what,'ecosmex')) || any(strcmpi(what,'all')) )
         cmd = sprintf('mex %s -lut -lm amd_1.o   amd_2.o   amd_aat.o   amd_control.o   amd_defaults.o   amd_dump.o   amd_global.o   amd_info.o   amd_order.o   amd_post_tree.o   amd_postorder.o   amd_preprocess.o   amd_valid.o     ldl.o   kkt.o   preproc.o   spla.o   cone.o   ecos.o ctrlc.o timer.o   splamm.o   equil.o  ecos_mex.o ecos_bb.o ecos_bb_preproc.o -output "ecos"', d);
         eval(cmd);
     elseif( isunix )
-        cmd = sprintf('mex %s -lut -lm -lrt amd_1.o   amd_2.o   amd_aat.o   amd_control.o   amd_defaults.o   amd_dump.o   amd_global.o   amd_info.o   amd_order.o   amd_post_tree.o   amd_postorder.o   amd_preprocess.o   amd_valid.o     ldl.o   kkt.o   preproc.o   spla.o   cone.o   ecos.o ctrlc.o timer.o   splamm.o   equil.o  ecos_mex.o ecos_bb.o ecos_bb_preproc.o -output "ecos"', d);
+        cmd = sprintf('mex %s -lut -lm -lrt amd_1.o   amd_2.o   amd_aat.o   amd_control.o   amd_defaults.o   amd_dump.o   amd_global.o   amd_info.o   amd_order.o   amd_post_tree.o   amd_postorder.o  expcone.o wright_omega.o amd_preprocess.o   amd_valid.o     ldl.o   kkt.o   preproc.o   spla.o   cone.o   ecos.o ctrlc.o timer.o   splamm.o   equil.o  ecos_mex.o ecos_bb.o ecos_bb_preproc.o -output "ecos"', d);
         eval(cmd);
     end
     fprintf('\t\t\t\t[done]\n');

--- a/bin/makemex.m
+++ b/bin/makemex.m
@@ -108,7 +108,7 @@ end
 %% ecos_mex
 if( any(strcmpi(what,'ecosmex')) || any(strcmpi(what,'all')) )
     fprintf('Compiling ecos_mex...');
-    cmd = sprintf('mex -c -O -DMATLAB_MEX_FILE -DCTRLC=1 -DMEXARGMUENTCHECKS %s -I../ecos/include -I../ecos/external/SuiteSparse_config -I../ecos/external/ldl/include -I../ecos/external/amd/include src/ecos_mex.c', d);
+    cmd = sprintf('mex -c -O -DMATLAB_MEX_FILE -DCTRLC=1 -DMEXARGMUENTCHECKS %s -I../ecos/include -I../ecos/external/SuiteSparse_config -I../ecos/external/ldl/include -I../ecos/external/amd/include ../src/ecos_mex.c', d);
     eval(cmd);
     fprintf('\t\t\t[done]\n');
     fprintf('Linking...     ');

--- a/bin/makemex.m
+++ b/bin/makemex.m
@@ -108,7 +108,7 @@ end
 %% ecos_mex
 if( any(strcmpi(what,'ecosmex')) || any(strcmpi(what,'all')) )
     fprintf('Compiling ecos_mex...');
-    cmd = sprintf('mex -c -O -DMATLAB_MEX_FILE -DCTRLC=1 -DMEXARGMUENTCHECKS %s -I../ecos/include -I../ecos/external/SuiteSparse_config -I../ecos/external/ldl/include -I../ecos/external/amd/include ../src/ecos_mex.c', d);
+    cmd = sprintf('mex -c -O -DMATLAB_MEX_FILE -DCTRLC=1 -DMEXARGMUENTCHECKS %s -I../ecos/include -I../ecos/external/SuiteSparse_config -I../ecos/external/ldl/include -I../ecos/external/amd/include src/ecos_mex.c', d);
     eval(cmd);
     fprintf('\t\t\t[done]\n');
     fprintf('Linking...     ');

--- a/src/ecos_mex.c
+++ b/src/ecos_mex.c
@@ -427,7 +427,11 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
 #endif
 
     /* find out dimensions of cones */    
-    l = (idxint)(*mxGetPr(dims_l)); numConicVariables += l;
+    if( dims_l != NULL) {
+      l = (idxint)(*mxGetPr(dims_l)); numConicVariables += l;
+    } else {
+      l = 0;
+    }
     if( dims_q != NULL) {
         q = mxGetPr(dims_q);
     } else {

--- a/src/ecos_mex.c
+++ b/src/ecos_mex.c
@@ -490,7 +490,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
             if(opts_mi_integer_tol != NULL ){ opts_ecos_bb.integer_tol = (pfloat)(*mxGetPr(opts_mi_integer_tol));}
         }
 
-        bb_pwork = ECOS_BB_setup(n, m, p, l, ncones, qint, Gpr, Gjc, Gir, Apr, Ajc, Air, 
+        bb_pwork = ECOS_BB_setup(n, m, p, l, ncones, qint, 0, Gpr, Gjc, Gir, Apr, Ajc, Air, 
             cpr, hpr, bpr, num_bool_vars, bool_vars_idx, num_int_vars, int_vars_idx, &opts_ecos_bb);
         
         mywork = bb_pwork->ecos_prob;
@@ -500,7 +500,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         
     }else{
         /* This calls ECOS setup function. */
-        mywork = ECOS_setup(n, m, p, l, ncones, qint, Gpr, Gjc, Gir, Apr, Ajc, Air, cpr, hpr, bpr);
+        mywork = ECOS_setup(n, m, p, l, ncones, qint, 0, Gpr, Gjc, Gir, Apr, Ajc, Air, cpr, hpr, bpr);
     }    
     
     if( mywork == NULL ){


### PR DESCRIPTION
This showed up in yalmiptest('ecos'). It lead to MATLAB segfaulting. This check fixes things, I believe.
